### PR TITLE
VSEBP-38 Allow overwriting resolver hosts with environment variables

### DIFF
--- a/src/Gateway/graphify/src/configuration/query.ts
+++ b/src/Gateway/graphify/src/configuration/query.ts
@@ -18,7 +18,8 @@ export type QueryArgument = {
 };
 
 export type ResolverDeclaration = {
-    url: string;
+    host: string;
+    endpoint: string;
     method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
 };
 

--- a/src/Gateway/graphify/src/query.config.json
+++ b/src/Gateway/graphify/src/query.config.json
@@ -4,7 +4,8 @@
             "name": "events",
             "args": [],
             "resolver": {
-                "url": "http://eventmanagementservice-service:8081/api/v1/books",
+                "host": "http://eventmanagementservice-service:8081",
+                "endpoint": "/api/v1/events",
                 "method": "GET"
             }
         },
@@ -18,7 +19,8 @@
                 }
             ],
             "resolver": {
-                "url": "http://eventmanagementservice-service:8081/api/v1/books/{id}",
+                "host": "http://eventmanagementservice-service:8081",
+                "endpoint": "/api/v1/events/{id}",
                 "method": "GET"
             }
         },
@@ -26,7 +28,8 @@
             "name": "todos",
             "args": [],
             "resolver": {
-                "url": "https://jsonplaceholder.typicode.com/todos",
+                "host": "https://jsonplaceholder.typicode.com",
+                "endpoint": "/todos",
                 "method": "GET"
             }
         }

--- a/src/Gateway/graphify/src/query.config.json
+++ b/src/Gateway/graphify/src/query.config.json
@@ -4,8 +4,17 @@
             "name": "events",
             "args": [],
             "resolver": {
-                "host": "http://eventmanagementservice-service:8081",
+                "host": "http://eventmanagementservice-service:8080",
                 "endpoint": "/api/v1/events",
+                "method": "GET"
+            }
+        },
+        {
+            "name": "allPublicEvents",
+            "args": [],
+            "resolver": {
+                "host": "http://eventmanagementservice-service:8080",
+                "endpoint": "/api/v1/events/allPublicEvents",
                 "method": "GET"
             }
         },
@@ -19,7 +28,7 @@
                 }
             ],
             "resolver": {
-                "host": "http://eventmanagementservice-service:8081",
+                "host": "http://eventmanagementservice-service:8080",
                 "endpoint": "/api/v1/events/{id}",
                 "method": "GET"
             }

--- a/src/Gateway/graphify/src/schema.graphql
+++ b/src/Gateway/graphify/src/schema.graphql
@@ -29,6 +29,7 @@ type Todo {
 
 type Query {
     events: [Event]
+    allPublicEvents: [Event]
     event(id: Int): Event
     todos: [Todo]
 }


### PR DESCRIPTION
It is important that we can substitute the resolver hosts at deploy time. We want the Gateway to get the actual GCP urls when deploying. This PR will allow the gateway to replace all hosts using environment variables. 

E.g. if we have a query called `events` that fetches all events, then we can overwrite the resolver url by setting the environment variable `QUERY_EVENTS_HOST=http://some_url.com`

