### PR TITLE
VSEBP-133: Add support for Mutations in GraphQL API Gateway

### DIFF
--- a/src/Gateway/graphify/src/configuration/query.ts
+++ b/src/Gateway/graphify/src/configuration/query.ts
@@ -3,6 +3,7 @@ import * as fs from "fs";
 
 export type QueryConfiguration = {
     queries: QueryDeclaration[];
+    mutations: QueryDeclaration[];
 };
 
 export type QueryDeclaration = {
@@ -22,6 +23,7 @@ export type ResolverDeclaration = {
     port: number;
     endpoint: string;
     method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+    headers?: Map<string, string>;
 };
 
 const QUERY_CONFIG_FILE = "query.config.json";

--- a/src/Gateway/graphify/src/configuration/query.ts
+++ b/src/Gateway/graphify/src/configuration/query.ts
@@ -15,7 +15,7 @@ export type QueryDeclaration = {
 export type QueryArgument = {
     name: string;
     type: string;
-    for: "url" | "body";
+    for: "urlPath" | "urlQueryParam" | "body";
 };
 
 export type ResolverDeclaration = {

--- a/src/Gateway/graphify/src/gateway.ts
+++ b/src/Gateway/graphify/src/gateway.ts
@@ -5,6 +5,7 @@ export type GatewayConfig = {
     typeDefs: string;
     resolvers: {
         Query: any;
+        Mutation: any;
     };
     port: number | undefined | null;
 };
@@ -24,7 +25,7 @@ export function gateway(config: GatewayConfig): Gateway {
             listen: { port: config.port ?? 4242, host: "0.0.0.0" },
         });
 
-        console.log(`🚀  Server ready at: ${url}`);
+        console.log(`🚀  Server ready on port: ${config.port}`);
     };
 
     return { start };

--- a/src/Gateway/graphify/src/query.config.json
+++ b/src/Gateway/graphify/src/query.config.json
@@ -37,13 +37,44 @@
             }
         },
         {
-            "name": "todos",
+            "name": "posts",
             "args": [],
             "resolver": {
                 "host": "https://jsonplaceholder.typicode.com",
-                "endpoint": "/todos",
+                "endpoint": "/posts",
                 "port": 80,
                 "method": "GET"
+            }
+        }
+    ],
+    "mutations": [
+        {
+            "name": "createPost",
+            "args": [
+                {
+                    "name": "userId",
+                    "type": "Int!",
+                    "for": "body"
+                },
+                {
+                    "name": "title",
+                    "type": "String!",
+                    "for": "body"
+                },
+                {
+                    "name": "body",
+                    "type": "String!",
+                    "for": "body"
+                }
+            ],
+            "resolver": {
+                "host": "https://jsonplaceholder.typicode.com",
+                "endpoint": "/posts",
+                "port": 80,
+                "headers": {
+                    "Content-Type": "application/json; charset=UTF-8"
+                },
+                "method": "POST"
             }
         }
     ]

--- a/src/Gateway/graphify/src/query.config.json
+++ b/src/Gateway/graphify/src/query.config.json
@@ -48,7 +48,23 @@
             "resolver": {
                 "host": "https://jsonplaceholder.typicode.com",
                 "endpoint": "/posts",
-                "port": 80,
+                "port": 443,
+                "method": "GET"
+            }
+        },
+        {
+            "name": "post",
+            "args": [
+                {
+                    "name": "id",
+                    "type": "Int!",
+                    "for": "urlPath"
+                }
+            ],
+            "resolver": {
+                "host": "https://jsonplaceholder.typicode.com",
+                "endpoint": "/posts/{id}",
+                "port": 443,
                 "method": "GET"
             }
         }

--- a/src/Gateway/graphify/src/query.config.json
+++ b/src/Gateway/graphify/src/query.config.json
@@ -26,7 +26,7 @@
                 {
                     "name": "id",
                     "type": "Int",
-                    "for": "url"
+                    "for": "urlPath"
                 }
             ],
             "resolver": {
@@ -38,7 +38,13 @@
         },
         {
             "name": "posts",
-            "args": [],
+            "args": [
+                {
+                    "name": "userId",
+                    "type": "Int",
+                    "for": "urlQueryParam"
+                }
+            ],
             "resolver": {
                 "host": "https://jsonplaceholder.typicode.com",
                 "endpoint": "/posts",

--- a/src/Gateway/graphify/src/resolver.ts
+++ b/src/Gateway/graphify/src/resolver.ts
@@ -42,24 +42,32 @@ function buildResolver(resolvers: any, config: QueryDeclaration) {
         const requestOptions: RequestInit = {
             method: config.resolver.method,
             headers: config.resolver.headers as HeadersInit | undefined,
-            body,
         };
+
+        if (hasBodyArgs) {
+            requestOptions.body = body;
+        }
 
         const url = expandUrlParams(args, config);
         console.log(`Routing request to: ${url}`);
         console.log(
             `Request Options: ${JSON.stringify(requestOptions, null, 4)}`
         );
-        const res = await fetch(url, requestOptions);
-        const resBody = await res.json();
-        console.log(
-            `Received response: ${JSON.stringify(res.status, undefined, 4)}`
-        );
-        console.log(
-            `Response body: ${JSON.stringify(resBody, undefined, 4)}\n`
-        );
+        try {
+            const res = await fetch(url, requestOptions);
+            const resBody = await res.json();
+            console.log(
+                `Received response: ${JSON.stringify(res.status, undefined, 4)}`
+            );
+            console.log(
+                `Response body: ${JSON.stringify(resBody, undefined, 4)}\n`
+            );
 
-        return resBody;
+            return resBody;
+        } catch (err) {
+            console.error(err);
+            throw err;
+        }
     };
 }
 

--- a/src/Gateway/graphify/src/schema.graphql
+++ b/src/Gateway/graphify/src/schema.graphql
@@ -33,6 +33,7 @@ type Query {
     allPublicEvents: [Event]
     event(id: Int): Event
     posts(userId: Int): [Post]
+    post(id: Int!): Post
 }
 
 type Mutation {

--- a/src/Gateway/graphify/src/schema.graphql
+++ b/src/Gateway/graphify/src/schema.graphql
@@ -14,22 +14,27 @@ type Location {
 }
 
 type Event {
+    id: String
     title: String
     location: Location
     url: String
     description: String
 }
 
-type Todo {
+type Post {
     userId: Int
     id: Int
     title: String
-    completed: Boolean
+    body: String
 }
 
 type Query {
     events: [Event]
     allPublicEvents: [Event]
     event(id: Int): Event
-    todos: [Todo]
+    posts: [Post]
+}
+
+type Mutation {
+    createPost(userId: Int!, title: String!, body: String!): Post
 }

--- a/src/Gateway/graphify/src/schema.graphql
+++ b/src/Gateway/graphify/src/schema.graphql
@@ -32,7 +32,7 @@ type Query {
     events: [Event]
     allPublicEvents: [Event]
     event(id: Int): Event
-    posts: [Post]
+    posts(userId: Int): [Post]
 }
 
 type Mutation {


### PR DESCRIPTION
- Adds support for configuration of mutation resolvers
- Adds support for  configuration of headers in `query.config.json`
- Renamed argument `for` type from `url` to `urlPath`
- Adds new argument target `urlQueryParam`, so we can configure resolvers to reroute to paths such as `GET /posts?userId=1` 