### PR TITLE
prevent users from joining ended events

### DIFF
--- a/src/Services/EventManagementService/EventManagementService.API/Controllers/V1/EventControllers/AttendeesController.cs
+++ b/src/Services/EventManagementService/EventManagementService.API/Controllers/V1/EventControllers/AttendeesController.cs
@@ -40,6 +40,10 @@ public class AttendeesController : ControllerBase
         {
             return Conflict(e.Message);
         }
+        catch (EventHasEndedException e)
+        {
+            return BadRequest(e.Message);
+        }
         catch (Exception e)
         {
             _logger.LogError(e.Message, e);

--- a/src/Services/EventManagementService/EventManagementService.Application/V1/JoinEvent/Exceptions/EventHasEndedException.cs
+++ b/src/Services/EventManagementService/EventManagementService.Application/V1/JoinEvent/Exceptions/EventHasEndedException.cs
@@ -1,0 +1,11 @@
+namespace EventManagementService.Application.V1.JoinEvent.Exceptions;
+
+public class EventHasEndedException: Exception
+{
+    public EventHasEndedException(int eventId, Exception? inner = null) :
+        base($"Unable to join event {eventId}. Event has already ended.")
+
+    {
+
+    }
+}

--- a/src/Services/EventManagementService/EventManagementService.Application/V1/JoinEvent/JoinEventHandler.cs
+++ b/src/Services/EventManagementService/EventManagementService.Application/V1/JoinEvent/JoinEventHandler.cs
@@ -76,6 +76,11 @@ public class JoinEventHandler : IRequestHandler<JoinEventRequest>
             throw new UserIsAlreadyHostOfEventException(request.UserId, existingEvent.Id);
         }
 
+        if (DateTimeOffset.UtcNow.ToUniversalTime() > existingEvent.EndDate.ToUniversalTime())
+        {
+            throw new EventHasEndedException(existingEvent.Id);
+        }
+
         await AcceptInvitationIfInvited(request.UserId, request.EventId);
 
         await _eventRepository.AddAttendeeToEventAsync(request.UserId, request.EventId);


### PR DESCRIPTION
Thought about this case while writing the use-case description for "Sign up for events".
Does not really make sense to join events that has already ended. 